### PR TITLE
Extension methods & Custom Doc routes, names, descriptions

### DIFF
--- a/src/SwashbuckleAspNetVersioningShim/SwaggerVersionOptions.cs
+++ b/src/SwashbuckleAspNetVersioningShim/SwaggerVersionOptions.cs
@@ -1,0 +1,18 @@
+﻿
+namespace SwashbuckleAspNetVersioningShim
+{
+    public class SwaggerVersionOptions
+    {
+        /// <summary>
+        /// Template for locating swagger documents inside Swagger Ui.
+        /// Document version number (without "v") will be substituted for "{0}".
+        /// </summary>
+        public string RouteTemplate { get; set; } = "/swagger/v{0}/swagger.json";
+
+        /// <summary>
+        /// Template for description of each swagger doc in the ui.
+        /// Document version number (without "v") will be substituted for "{0}".
+        /// </summary>
+        public string DescriptionTemplate { get; set; } = "v{0} Docs";
+    }
+}

--- a/src/SwashbuckleAspNetVersioningShim/SwaggerVersioner.cs
+++ b/src/SwashbuckleAspNetVersioningShim/SwaggerVersioner.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Swashbuckle.AspNetCore.Swagger;
@@ -12,7 +13,13 @@ namespace SwashbuckleAspNetVersioningShim
 {
     public static class SwaggerVersioner
     {
+        [Obsolete("Use ConfigureSwaggerVersions instead.")]
         public static void ConfigureSwaggerGen(SwaggerGenOptions swaggerOptions, ApplicationPartManager partManager)
+        {
+            swaggerOptions.ConfigureSwaggerVersions(partManager);
+        }
+
+        public static void ConfigureSwaggerVersions(this SwaggerGenOptions swaggerOptions, ApplicationPartManager partManager)
         {
             var allVersions = GetAllApiVersions(partManager);
             foreach (var version in allVersions)
@@ -36,7 +43,7 @@ namespace SwashbuckleAspNetVersioningShim
             swaggerOptions.DocumentFilter<SetVersionInPathsDocumentFilter>();
         }
 
-        public static List<string> GetAllApiVersions(ApplicationPartManager partManager)
+        public static List<string> GetAllApiVersions(this ApplicationPartManager partManager)
         {
             var controllerFeature = new ControllerFeature();
             partManager.PopulateFeature(controllerFeature);
@@ -47,7 +54,13 @@ namespace SwashbuckleAspNetVersioningShim
             return versionList;
         }
 
+        [Obsolete("Use ConfigureSwaggerVersions instead.")]
         public static void ConfigureSwaggerUI(SwaggerUIOptions swaggerUIOptions, ApplicationPartManager partManager)
+        {
+            swaggerUIOptions.ConfigureSwaggerVersions(partManager);
+        }
+
+        public static void ConfigureSwaggerVersions(this SwaggerUIOptions swaggerUIOptions, ApplicationPartManager partManager)
         {
             var versions = GetAllApiVersions(partManager);
             foreach (var version in versions)

--- a/src/SwashbuckleAspNetVersioningShim/SwaggerVersioner.cs
+++ b/src/SwashbuckleAspNetVersioningShim/SwaggerVersioner.cs
@@ -16,15 +16,21 @@ namespace SwashbuckleAspNetVersioningShim
         [Obsolete("Use ConfigureSwaggerVersions instead.")]
         public static void ConfigureSwaggerGen(SwaggerGenOptions swaggerOptions, ApplicationPartManager partManager)
         {
-            swaggerOptions.ConfigureSwaggerVersions(partManager);
+            swaggerOptions.ConfigureSwaggerVersions(partManager, "API Version {0}");
         }
 
         public static void ConfigureSwaggerVersions(this SwaggerGenOptions swaggerOptions, ApplicationPartManager partManager)
         {
+            swaggerOptions.ConfigureSwaggerVersions(partManager, "API Version {0}");
+        }
+
+        public static void ConfigureSwaggerVersions(this SwaggerGenOptions swaggerOptions, ApplicationPartManager partManager, string titleFormat)
+        {
             var allVersions = GetAllApiVersions(partManager);
             foreach (var version in allVersions)
             {
-                swaggerOptions.SwaggerDoc($"v{version}", new Info { Version = version, Title = $"API Version {version}" });
+                var title = string.Format(titleFormat, version);
+                swaggerOptions.SwaggerDoc($"v{version}", new Info { Version = version, Title = title });
             }
 
             swaggerOptions.DocInclusionPredicate((version, apiDescription) =>
@@ -57,15 +63,22 @@ namespace SwashbuckleAspNetVersioningShim
         [Obsolete("Use ConfigureSwaggerVersions instead.")]
         public static void ConfigureSwaggerUI(SwaggerUIOptions swaggerUIOptions, ApplicationPartManager partManager)
         {
-            swaggerUIOptions.ConfigureSwaggerVersions(partManager);
+            swaggerUIOptions.ConfigureSwaggerVersions(partManager, new SwaggerVersionOptions());
         }
 
         public static void ConfigureSwaggerVersions(this SwaggerUIOptions swaggerUIOptions, ApplicationPartManager partManager)
         {
+            swaggerUIOptions.ConfigureSwaggerVersions(partManager, new SwaggerVersionOptions());
+        }
+
+        public static void ConfigureSwaggerVersions(this SwaggerUIOptions swaggerUIOptions, ApplicationPartManager partManager, SwaggerVersionOptions versionOptions)
+        {
             var versions = GetAllApiVersions(partManager);
             foreach (var version in versions)
             {
-                swaggerUIOptions.SwaggerEndpoint($"/swagger/v{version}/swagger.json", $"v{version} Docs");
+                var url = string.Format(versionOptions.RouteTemplate, version);
+                var description = string.Format(versionOptions.DescriptionTemplate, version);
+                swaggerUIOptions.SwaggerEndpoint(url, description);
             }
         }
     }


### PR DESCRIPTION
Hey! Love this lib. Figured I'd contribute some minor improvements that I noticed I wanted.

1) Extension methods.
Just looks cleaner, no? But I changed two of the method names in the process to make it clear this is configuring versioning. I left the original method names in as non-extension methods but marked obsolete for backwards compatibility.

2) Custom doc routes, names, and descriptions.
I wanted to move all my api docs to "/docs" but couldn't, also I wanted to display slightly more descriptive doc names. This would allow that customization and I think it's still pretty clean.